### PR TITLE
chore: use pnpm version for releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "build": "rs lib",
-    "bump": "pnpx bumpp --no-push --no-tag --no-commit",
+    "bump": "pnpm version -m \"release: v%s\"",
     "check": "rs check",
     "dev": "rs lib -w",
     "format": "rs fmt",


### PR DESCRIPTION
## Summary

Use pnpm's built-in version command for release preparation, matching rspack-vue-loader. Replace `pnpx bumpp --no-push --no-tag --no-commit` with `pnpm version -m "release: v%s"`.

The bump script now creates a local release commit and version tag; the previous script disabled both. Pushing remains a separate step.